### PR TITLE
jQuery hook and easy JS-editable configuration of defaults

### DIFF
--- a/js/cherry.lazy-load.js
+++ b/js/cherry.lazy-load.js
@@ -1,42 +1,68 @@
-function getWindowHeight() {
-    var myWidth = 0, myHeight = 0;
-    if( typeof( window.innerWidth ) == 'number' ) {
-        //Non-IE
-        myHeight = window.innerHeight;
-    } else if( document.documentElement && ( document.documentElement.clientWidth || document.documentElement.clientHeight ) ) {
-        //IE 6+ in 'standards compliant mode'
-        myHeight = document.documentElement.clientHeight;
-    } else if( document.body && ( document.body.clientWidth || document.body.clientHeight ) ) {
-        //IE 4 compatible
-        myHeight = document.body.clientHeight;
-    }
+CherryLazyLoadPlugin = new (function($){
+    var effects = ['effect-slideup', '.trigger.effect-slidedown', '.trigger.effect-slidefromleft', '.trigger.effect-slidefromright', '.trigger.effect-zoomin', '.trigger.effect-zoomout', '.trigger.effect-rotate', '.trigger.effect-skew']
+    /* Can be set programatically later instead of adding a tag class to the DOM */
+    this.useCSSAnimations = jQuery('.cssanimations').length;
+    /* Default delay */
+    this.defaultDelay = undefined;
+    /* Default speed */
+    this.defaultSpeed = undefined;
 
-    return myHeight
-}
+    var that = this;
+    function getWindowHeight() {
+        var myWidth = 0, myHeight = 0;
+        if( typeof( window.innerWidth ) == 'number' ) {
+            //Non-IE
+            myHeight = window.innerHeight;
+        } else if( document.documentElement && ( document.documentElement.clientWidth || document.documentElement.clientHeight ) ) {
+            //IE 6+ in 'standards compliant mode'
+            myHeight = document.documentElement.clientHeight;
+        } else if( document.body && ( document.body.clientWidth || document.body.clientHeight ) ) {
+            //IE 4 compatible
+            myHeight = document.body.clientHeight;
+        }
 
-function appearBox(element, element_top, bottom_of_window) {
-    /* If the object is completely visible in the window, fade it it */
-    var buffer = element.outerHeight()/2;
-    if( bottom_of_window > element_top + buffer) {
-        setTimeout(function(){
-            if ( jQuery('.cssanimations').length ) {
-                element.removeClass('trigger');
-            } else {
-                element.removeClass('trigger').animate({'opacity':'1'}, element.data('speed'));
-            }
-        }, element.data('delay'));            
-    }
-}
+        return myHeight
+    };
 
+    function appearBox(element, element_top, bottom_of_window) {
+        /* If the object is completely visible in the window, fade it it */
+        var buffer = $(element).outerHeight()/2;
+        if( bottom_of_window > element_top + buffer) {
+            setTimeout(function(){
+                if ( that.useCSSAnimations ) {
+                    element.removeClass('trigger');
+                } else {
+                    element.removeClass('trigger').animate({'opacity':'1'}, element.data('speed') !== undefined? element.data('speed') : that.defaultSpeed);
+                }
+            }, element.data('delay') !== undefined? element.data('delay') : that.defaultDelay);            
+        }
+    };
 
-(function($) {
+    function registerAnimation(element, effect, delay, speed) {
+        effect = effect || 'random'
+        if(effect == 'random'){
+            effect = effects[Math.floor(Math.random()*effects.length)];
+        }
+        $(element).addClass('lazy-load-box').addClass('trigger').addClass(effect);
+
+        if(delay !== undefined)
+            $(element).attr('data-delay', delay)
+
+        if(speed !== undefined)
+            $(element).attr('data-speed', speed)
+    };
+    this.registerAnimation = registerAnimation;
+    $.fn.cherryLazyLoad = function(effect, delay, speed){ 
+        /* Add a quick jQuery hook */
+        registerAnimation(this, effect, delay, speed);
+    };
+
     $(window).load(function() {
         if(!device.mobile() && !device.tablet()){
             $('.lazy-load-box.trigger').each( function(i){
                 var element_offset = $(this).offset();
                 var element_top = element_offset.top;
                 var bottom_of_window = $(window).scrollTop() + getWindowHeight();
-                
                 appearBox($(this), element_top, bottom_of_window);
             });
 
@@ -44,13 +70,11 @@ function appearBox(element, element_top, bottom_of_window) {
             $(window).scroll( function() {
                 /* Check the location of each desired element */
                 $('.lazy-load-box.trigger').each( function(i){
-                    
                     var element_offset = $(this).offset(),
                         element_top = element_offset.top,
                         bottom_of_window = $(window).scrollTop() + getWindowHeight();
                     
                     appearBox($(this), element_top, bottom_of_window);
-                    
                 }); 
             
             });
@@ -60,4 +84,4 @@ function appearBox(element, element_top, bottom_of_window) {
             });
         }
     });
-})(jQuery);
+})(jQuery); /* Initialize with old defaults */

--- a/js/cherry.lazy-load.js
+++ b/js/cherry.lazy-load.js
@@ -1,5 +1,5 @@
 CherryLazyLoadPlugin = new (function($){
-    var effects = ['effect-slideup', '.trigger.effect-slidedown', '.trigger.effect-slidefromleft', '.trigger.effect-slidefromright', '.trigger.effect-zoomin', '.trigger.effect-zoomout', '.trigger.effect-rotate', '.trigger.effect-skew']
+    var effects = ['effect-slideup', 'effect-slidedown', 'effect-slidefromleft', 'effect-slidefromright', 'effect-zoomin', 'effect-zoomout', 'effect-rotate', 'effect-skew']
     /* Can be set programatically later instead of adding a tag class to the DOM */
     this.useCSSAnimations = jQuery('.cssanimations').length;
     /* Default delay */
@@ -39,7 +39,7 @@ CherryLazyLoadPlugin = new (function($){
     };
 
     function registerAnimation(element, effect, delay, speed) {
-        effect = effect || 'random'
+        var effect = effect || 'random'
         if(effect == 'random'){
             effect = effects[Math.floor(Math.random()*effects.length)];
         }
@@ -53,8 +53,10 @@ CherryLazyLoadPlugin = new (function($){
     };
     this.registerAnimation = registerAnimation;
     $.fn.cherryLazyLoad = function(effect, delay, speed){ 
-        /* Add a quick jQuery hook */
-        registerAnimation(this, effect, delay, speed);
+        /* Add a quick jQuery hook. Register each element individually, especially for `random` effect. */
+        $(this).each(function(){ 
+            registerAnimation(this, effect, delay, speed);
+        })
     };
 
     $(window).load(function() {


### PR DESCRIPTION
Added some ways to configure the plugin programatically instead of altering the DOM (easier to plug in an existing non-WP website). 
Added a quick hook to register animations to DOM elements using jQuery.
Added a 'random' option to the jQuery hook to register a random animation to one or multiple elements.
The old behavior has NOT been changed and the new version is 100% backward compatible.
Example of new possible usage:
  CherryLazyLoadPlugin.useCSSAnimations = true;
  CherryLazyLoadPlugin.defaultDelay = 100;
  $(".video").cherryLazyLoad('effect-zoomin')
  $("h3").cherryLazyLoad('effect-slidefromleft', 200)
  $("#Blog .readmore").cherryLazyLoad('random') // Random animations